### PR TITLE
Log container names

### DIFF
--- a/support_test.go
+++ b/support_test.go
@@ -75,14 +75,14 @@ func (m *mockFilter) ShouldTailLogs(pod *Pod) (bool, error) {
 
 // mockLogOutput implements the LogOutput interface
 type mockLogOutput struct {
-	LastLogged    string
+	LastLogged    *LogLine
 	WasCalled     bool
 	CallCount     int
 	StopWasCalled bool
 	sync.Mutex
 }
 
-func (m *mockLogOutput) Log(line string) {
+func (m *mockLogOutput) Log(line *LogLine) {
 	m.Lock()
 	m.WasCalled = true
 	m.LastLogged = line


### PR DESCRIPTION
This implements this pretty far down. Ideally we would do it in discovery. But this solution will work and prevents a lot of replumbing.

This also speeds up the tests quite a bit (they were already pretty fast) by not waiting a fixed amount of time (300ms) in a couple of places. It only waits *up to* 300ms now, using a timeout.