### PR TITLE
Use dynamic service name

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func NewTailerWithUDPSyslog(c *cache.Cache, hostname string,
 		}, config.SyslogAddress)
 
 		// Inject the UDPSyslogger into the RateLimitingLogger
-		limitingLogger := NewRateLimitingLogger(rptr, config.TokenLimit, config.LimitInterval, "ServiceName", udpLogger)
+		limitingLogger := NewRateLimitingLogger(rptr, config.TokenLimit, config.LimitInterval, pod.ServiceName, udpLogger)
 
 		// Wrap the return value from NewTailer as an interface
 		return NewTailer(pod, c, limitingLogger)


### PR DESCRIPTION
This fixes a bug that @patoms found, where we were using the key "ServiceName" rather than the container label value by that key. This means it was kind of running a a host-based limiter rather than per service!! Not sure how long this has been broken.