### PR TITLE
Fix extracting ServiceName for both dashes and underscores

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,13 +8,14 @@ import (
 	"syscall"
 	"time"
 
+	_ "net/http/pprof"
+
 	"github.com/Shimmur/logtailer/cache"
 	"github.com/Shimmur/logtailer/reporter"
 	"github.com/kelseyhightower/envconfig"
 	director "github.com/relistan/go-director"
 	"github.com/relistan/rubberneck"
 	log "github.com/sirupsen/logrus"
-	_ "net/http/pprof"
 )
 
 const (
@@ -155,6 +156,7 @@ func main() {
 		)
 		if tailAllFilter != nil {
 			filter = tailAllFilter
+			log.Info("Staring in tail all mode, here be dragons")
 		} else {
 			log.Warn("Failed to configure TailAll filter, proceeding anyway using stub...")
 			filter = &StubFilter{TailAll: true}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,8 @@ type Config struct {
 	DiscoInterval  time.Duration `envconfig:"DISCO_INTERVAL" default:"5s"`
 	MaxTrackedLogs int           `envconfig:"MAX_TRACKED_LOGS" default:"100"`
 
+	TailAll        bool          `envconfig:"TAIL_ALL" default:"false"`
+
 	CacheFilePath      string        `envconfig:"CACHE_FILE_PATH" default:"/var/log/logtailer.json"`
 	CacheFlushInterval time.Duration `envconfig:"CACHE_FLUSH_INTERVAL" default:"3s"`
 
@@ -137,7 +139,7 @@ func main() {
 	// Some deps for injection
 	cache := configureCache(config)
 	podFilter := NewPodFilter(
-		config.KubeHost, config.KubePort, config.KubeTimeout, config.KubeCredsPath,
+		config.KubeHost, config.KubePort, config.KubeTimeout, config.KubeCredsPath, config.TailAll,
 	)
 	disco := NewDirListDiscoverer(config.BasePath, config.Environment)
 	rptr := reporter.NewLimitExceededReporter(
@@ -154,7 +156,7 @@ func main() {
 		filter = podFilter
 	} else {
 		log.Warn("Failed to configure filter, proceeding anyway using stub...")
-		filter = &StubFilter{}
+		filter = &StubFilter{TailAll: config.TailAll}
 	}
 
 	// Set up and run the tracker

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ type Config struct {
 	DiscoInterval  time.Duration `envconfig:"DISCO_INTERVAL" default:"5s"`
 	MaxTrackedLogs int           `envconfig:"MAX_TRACKED_LOGS" default:"100"`
 
-	TailAll        bool          `envconfig:"TAIL_ALL" default:"false"`
+	TailAll bool `envconfig:"TAIL_ALL" default:"false"`
 
 	CacheFilePath      string        `envconfig:"CACHE_FILE_PATH" default:"/var/log/logtailer.json"`
 	CacheFlushInterval time.Duration `envconfig:"CACHE_FLUSH_INTERVAL" default:"3s"`


### PR DESCRIPTION
This is a continuation on from #11

I noticed after creating the `TAIL_ALL` mode, if a `ServiceName=zapier_integration` and annotation `community.com/TailLogs=false`, logtailer would continue to tail the logs. It seems that the bug lies in the `ServiceName` using a `-` vs `_`.

Visual representation of what is going on:

<img width="3960" height="2176" alt="image" src="https://github.com/user-attachments/assets/5ddc3e58-caed-4706-b55d-4acf3a00a20d" />


This PR should address that bug.

Added Test Coverage

  For Both AnnotationPodFilter and TailAllFilter:

  1. ServiceName with Hyphens → Underscore Conversion:
    - Tests that zapier-integration gets converted to zapier_integration in the query
    - Verifies the URL contains ServiceName%3Dzapier_integration (URL-encoded)
  2. ServiceName with Underscores:
    - Tests that zapier_integration stays as zapier_integration in the query
    - Verifies the URL contains ServiceName%3Dzapier_integration
  3. Fallback to Direct Pod Query:
    - Tests the two-stage querying approach when ServiceName query returns no results
    - Verifies both queries are made in the correct order:
        i. First: ServiceName label selector query
      ii. Second: Direct pod name query using extractPodName()
  4. extractPodName Function:
    - Tests various pod directory name formats
    - Ensures proper extraction of Kubernetes pod names from file system paths
