### PR TITLE
Refresh service token on 401 from k8s API

### DIFF
--- a/k8s_pod_filter.go
+++ b/k8s_pod_filter.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -37,25 +38,23 @@ type PodFilter struct {
 	KubeHost string
 	KubePort int
 
-	token  string
-	client *http.Client
+	credsPath string
+	token     string
+	client    *http.Client
 }
 
 func NewPodFilter(kubeHost string, kubePort int, timeout time.Duration, credsPath string) *PodFilter {
 	f := &PodFilter{
-		Timeout:  timeout,
-		KubeHost: kubeHost,
-		KubePort: kubePort,
+		Timeout:   timeout,
+		KubeHost:  kubeHost,
+		KubePort:  kubePort,
+		credsPath: credsPath,
 	}
 	// Cache the secret from the file
-	data, err := ioutil.ReadFile(credsPath + "/token")
-	if err != nil {
+	if err := f.refreshToken(); err != nil {
 		log.Errorf("Failed to read serviceaccount token: %s", err)
 		return nil
 	}
-
-	// New line is illegal in tokens
-	f.token = strings.Replace(string(data), "\n", "", -1)
 
 	// Set up the timeout on a clean HTTP client
 	f.client = cleanhttp.DefaultClient()
@@ -86,6 +85,28 @@ func NewPodFilter(kubeHost string, kubePort int, timeout time.Duration, credsPat
 	return f
 }
 
+// refreshToken re-reads the service account token from disk. The kubelet
+// rotates this file before the token expires.
+func (f *PodFilter) refreshToken() error {
+	data, err := os.ReadFile(f.credsPath + "/token")
+	if err != nil {
+		return fmt.Errorf("failed to read serviceaccount token: %w", err)
+	}
+	// Newline is illegal in tokens
+	f.token = strings.Replace(string(data), "\n", "", -1)
+	return nil
+}
+
+func (f *PodFilter) newRequest(urlStr string) (*http.Request, error) {
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "logtailer/"+Version)
+	req.Header.Set("Authorization", "Bearer "+f.token)
+	return req, nil
+}
+
 func (f *PodFilter) makeRequest(path string) ([]byte, error) {
 	var scheme = "http"
 	if f.KubePort == 443 {
@@ -100,17 +121,34 @@ func (f *PodFilter) makeRequest(path string) ([]byte, error) {
 	apiURL.Scheme = scheme
 	apiURL.Host = fmt.Sprintf("%s:%d", f.KubeHost, f.KubePort)
 
-	req, err := http.NewRequest("GET", apiURL.String(), nil)
+	req, err := f.newRequest(apiURL.String())
 	if err != nil {
 		return []byte{}, err
 	}
 
-	req.Header.Set("User-Agent", "logtailer/"+Version)
-	req.Header.Set("Authorization", "Bearer "+f.token)
-
 	resp, err := f.client.Do(req)
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to fetch from K8s API '%s': %w", path, err)
+	}
+
+	// On 401, refresh the token from disk and retry once
+	if resp.StatusCode == http.StatusUnauthorized {
+		resp.Body.Close()
+
+		log.Warnf("Got 401 from K8s API for '%s', refreshing service account token", path)
+		if err := f.refreshToken(); err != nil {
+			return []byte{}, fmt.Errorf("failed to refresh token after 401: %w", err)
+		}
+
+		req, err = f.newRequest(apiURL.String())
+		if err != nil {
+			return []byte{}, err
+		}
+
+		resp, err = f.client.Do(req)
+		if err != nil {
+			return []byte{}, fmt.Errorf("failed to fetch from K8s API '%s' after token refresh: %w", path, err)
+		}
 	}
 	defer resp.Body.Close()
 

--- a/k8s_pod_filter_test.go
+++ b/k8s_pod_filter_test.go
@@ -23,6 +23,7 @@ func Test_NewPodFilter(t *testing.T) {
 			So(filter.KubeHost, ShouldEqual, "beowulf.example.com")
 			So(filter.KubePort, ShouldEqual, 443)
 			So(filter.token, ShouldContainSubstring, "this would be a token")
+			So(filter.credsPath, ShouldEqual, credsPath)
 			So(filter.client, ShouldNotBeNil)
 		})
 
@@ -110,6 +111,37 @@ func Test_makeRequest(t *testing.T) {
 
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "intentional test error")
+			So(body, ShouldBeEmpty)
+		})
+
+		Convey("refreshes token and retries on 401", func() {
+			callCount := 0
+			httpmock.RegisterResponder("GET", "http://beowulf.example.com:80/nowhere",
+				func(req *http.Request) (*http.Response, error) {
+					callCount++
+					if callCount == 1 {
+						return httpmock.NewJsonResponse(401, map[string]interface{}{"error": "unauthorized"})
+					}
+					return httpmock.NewJsonResponse(200, map[string]interface{}{"success": "yeah"})
+				},
+			)
+
+			body, err := filter.makeRequest("/nowhere")
+			So(err, ShouldBeNil)
+			So(body, ShouldNotBeEmpty)
+			So(callCount, ShouldEqual, 2)
+		})
+
+		Convey("returns error when retry after 401 also fails", func() {
+			httpmock.RegisterResponder("GET", "http://beowulf.example.com:80/nowhere",
+				func(req *http.Request) (*http.Response, error) {
+					return httpmock.NewJsonResponse(401, map[string]interface{}{"error": "unauthorized"})
+				},
+			)
+
+			body, err := filter.makeRequest("/nowhere")
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "got unexpected response code from /nowhere: 401")
 			So(body, ShouldBeEmpty)
 		})
 	})

--- a/log_output.go
+++ b/log_output.go
@@ -53,7 +53,7 @@ func parseLogFormat(logFormat string) LogFormat {
 	case "ruby":
 		chosenFormat = LogFormatRuby
 	case "go-logfmt", "":
-		fallthrough
+		chosenFormat = LogFormatGo
 	default:
 		log.Warnf("Unsupported log format '%s', falling back to 'go-logfmt'", logFormat)
 		chosenFormat = LogFormatGo

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ type Config struct {
 	KubeTimeout   time.Duration `envconfig:"KUBERNETES_TIMEOUT" default:"3s"`
 	KubeCredsPath string        `envconfig:"KUBERNETES_CREDS_PATH" default:"/var/run/secrets/kubernetes.io/serviceaccount"`
 
-	EnableRegexLogLevelParsing bool `envconfig:"ENABLE_REGEX_LOG_LEVEL_PARSING" default:false`
+	EnableRegexLogLevelParsing bool `envconfig:"ENABLE_REGEX_LOG_LEVEL_PARSING" default:"false"`
 
 	Debug bool `envconfig:"DEBUG" default:"false"`
 }

--- a/pod_tracker.go
+++ b/pod_tracker.go
@@ -92,7 +92,7 @@ func (t *PodTracker) Run() {
 			shouldTail, err := t.Filter.ShouldTailLogs(pod)
 			if err != nil {
 				log.Errorf(
-					"Failed to check filter for pod %s, disabling logging: %s", err, pod.Name,
+					"Failed to check filter for pod %s, disabling logging: %s", pod.Name, err,
 				)
 				continue
 			}

--- a/tailer.go
+++ b/tailer.go
@@ -205,6 +205,7 @@ func (t *Tailer) Run() {
 		for line := range t.LogChan {
 			t.logger.Log(line)
 		}
+		t.looper.Quit()
 		return nil
 	})
 }

--- a/tailer.go
+++ b/tailer.go
@@ -205,8 +205,7 @@ func (t *Tailer) Run() {
 		for line := range t.LogChan {
 			t.logger.Log(line)
 		}
-		t.looper.Quit()
-		return nil
+		return fmt.Errorf("log channel closed for pod %s", t.Pod.Name)
 	})
 }
 


### PR DESCRIPTION
kubernetes 1.35 or EKS v1.35 has changed the default token expiration, after 24hrs the service token is rotated on disk and we need to reread it else we'll get 401 unauthorized and logatailer will stop shipping logs

```
time="2026-03-03T20:16:17Z" level=error msg="Failed to check filter for pod got unexpected response code from /api/v1/namespaces/trino/pods?limit=100000&labelSelector=ServiceName%3Dtrino-worker: 401, disabling logging: trino_trino-worker-79b898cdc7-89nmp_f7ad2fa1-c54f-486e-acc9-be2009ca1cc5"
```
also:

Run() uses a FreeLooper(FOREVER) which re-calls the function after it returns. When LogChan is closed (cronjob pod finishes), range exits immediately, the function returns, and the looper re-invokes it in a tight loop, each iteration logging "Following logs for..." 100s of times.

```
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6'"
time="2026-03-04T17:38:55Z" level=info msg="  Closing tail on /var/log/pods/default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6/vault-init/0.log for pod default_campaign-msgs-alert-29544
093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6"
time="2026-03-04T17:38:55Z" level=info msg="All goroutines stopped for pod default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6"
time="2026-03-04T17:38:55Z" level=info msg="Following logs for 'default_campaign-msgs-alert-29544093-qxjnf_c1ce7207-fec7-43e7-82e1-0b8cd21e10f6
```