### PR TITLE
index and boundary checks

### DIFF
--- a/log_output.go
+++ b/log_output.go
@@ -84,6 +84,31 @@ func selectLogRegex(logFormat LogFormat) *regexp.Regexp {
 	return logFormatRegexes[logFormat]
 }
 
+// isWordChar returns true if the byte is a letter, digit, hyphen, or underscore.
+func isWordChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') || c == '-' || c == '_'
+}
+
+// containsWord checks if word appears in line as a standalone word
+// (not as part of a hyphenated flag like --show-error).
+func containsWord(line, word string) bool {
+	for i := 0; i < len(line); {
+		idx := strings.Index(line[i:], word)
+		if idx == -1 {
+			return false
+		}
+		abs := i + idx
+		before := abs == 0 || !isWordChar(line[abs-1])
+		after := abs+len(word) >= len(line) || !isWordChar(line[abs+len(word)])
+		if before && after {
+			return true
+		}
+		i = abs + len(word)
+	}
+	return false
+}
+
 // extractLogLevelWithRegex attempts to extract the log level using a pre-selected regex pattern.
 // This is the optimized version used internally by UDPSyslogger.
 // It returns the level string (e.g., "info", "error", "warning") and a boolean indicating
@@ -189,13 +214,13 @@ func (sysl *UDPSyslogger) Log(line *LogLine) {
 	// Fallback to heuristic detection (a la sidecar-executor)
 	// This is used when enhanced extraction is disabled or no structured level was found
 	lowerLine := strings.ToLower(lineTxt)
-	if descriptor == "stderr" || strings.Contains(lowerLine, "error") {
+	if descriptor == "stderr" || containsWord(lowerLine, "error") {
 		logger.Error(lineTxt)
 		return
 	}
 
 	// Support warning level by line-scraping as well
-	if strings.Contains(lowerLine, "warn") {
+	if containsWord(lowerLine, "warn") {
 		logger.Warn(lineTxt)
 		return
 	}

--- a/log_output_test.go
+++ b/log_output_test.go
@@ -84,6 +84,38 @@ func Test_extractLogLevelWithRegex(t *testing.T) {
 	})
 }
 
+func Test_containsWord(t *testing.T) {
+	Convey("containsWord()", t, func() {
+		Convey("does not match --show-error flag", func() {
+			So(containsWord("++ curl --show-error --fail", "error"), ShouldBeFalse)
+		})
+
+		Convey("does not match --warn-something flag", func() {
+			So(containsWord("--warn-something", "warn"), ShouldBeFalse)
+		})
+
+		Convey("matches standalone error", func() {
+			So(containsWord("an error occurred", "error"), ShouldBeTrue)
+		})
+
+		Convey("matches warn followed by colon", func() {
+			So(containsWord("warn: something bad", "warn"), ShouldBeTrue)
+		})
+
+		Convey("matches error in brackets", func() {
+			So(containsWord("[error] failed", "error"), ShouldBeTrue)
+		})
+
+		Convey("matches error as entire string", func() {
+			So(containsWord("error", "error"), ShouldBeTrue)
+		})
+
+		Convey("does not match error inside a word", func() {
+			So(containsWord("myerrorhandler", "error"), ShouldBeFalse)
+		})
+	})
+}
+
 func Test_selectLogRegex_ValidFormats(t *testing.T) {
 	Convey("selectLogRegex() with valid formats", t, func() {
 		Convey("LogFormatGo returns go-logfmt format", func() {


### PR DESCRIPTION
fixes for loglines like:

```
curl --silent --show-error --fail-with-body -XPOST http://campaign-tracker.default.svc.cluster.local:10034/archive-campaigns
```
  
 isWordChar(c byte) — checks if a byte is a letter, digit, hyphen, or underscore
 containsWord(line, word string) — checks if word appears as a standalone word (not part of a
  hyphenated flag like --show-error)

I know we don't want to use regex on the default matcher, so this is an alternative compromise to keep string matching speed fast.
